### PR TITLE
fix golint import for v0.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 install:
   - hack/install-seccomp.sh
   - hack/install-runc.sh
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 script:
   - make all


### PR DESCRIPTION
This should fix the CI error on https://github.com/containerd/containerd/pull/2768.  I tried to push to your fork but I'm not a maintainer so it denied :)

Signed-off-by: Evan Hazlett <ejhazlett@gmail.com>